### PR TITLE
feat: Implement user registration with signup API

### DIFF
--- a/syntexa-api/pom.xml
+++ b/syntexa-api/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version> <relativePath/> </parent>
+        <version>3.2.5</version> 
+        <relativePath/> 
+    </parent>
     <groupId>com.syntexa</groupId>
     <artifactId>syntexa-api</artifactId>
     <version>0.0.1-SNAPSHOT</version>
@@ -52,6 +54,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope> 
+        </dependency>
     </dependencies>
 
     <build>
@@ -71,4 +78,4 @@
         </plugins>
     </build>
 
-    </project>
+</project>

--- a/syntexa-api/src/main/java/com/syntexa/api/SyntexaApplication.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/SyntexaApplication.java
@@ -3,11 +3,10 @@ package com.syntexa.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication 
 public class SyntexaApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SyntexaApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(SyntexaApplication.class, args);
+    }
 }

--- a/syntexa-api/src/main/java/com/syntexa/api/config/SecurityConfig.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import static org.springframework.security.config.Customizer.withDefaults; 
 
@@ -12,16 +14,22 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+            .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
                     .requestMatchers("/api/v1/health").permitAll() 
+                    .requestMatchers("/api/v1/auth/**").permitAll()
                     .anyRequest().authenticated() 
             )
             .formLogin(withDefaults()); 
-            
-            // http.csrf(csrf -> csrf.disable()); // USE CAREFULLY FOR PRODUCTION
+              
 
         return http.build();
     }

--- a/syntexa-api/src/main/java/com/syntexa/api/controller/AuthController.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.syntexa.api.controller;
+
+import com.syntexa.api.dto.SignUpRequest;
+import com.syntexa.api.model.User;
+import com.syntexa.api.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController{
+
+    private final UserService userService;
+
+    @Autowired
+    public AuthController(UserService userService){
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerUser(@Valid @RequestBody SignUpRequest signUpRequest){
+
+        try{
+            User newUser = new User();
+            newUser.setUsername(signUpRequest.getUsername());
+            newUser.setEmail(signUpRequest.getEmail());
+            newUser.setPassword(signUpRequest.getPassword());
+
+            User registeredUser = userService.registerUser(newUser);
+            
+            return ResponseEntity.status(HttpStatus.CREATED).body("User registered successfully! Welcome"+ registeredUser.getUsername());
+        }
+        catch(IllegalArgumentException e){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+        catch(Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An unexpected error occured: "+ e.getMessage());
+        }
+    }
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/dto/SignUpRequest.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/dto/SignUpRequest.java
@@ -1,0 +1,27 @@
+package com.syntexa.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequest{
+    
+    @NotBlank(message = "Username cannot be blank")
+    @Size(min = 3, max=50, message = "Username must be between 3 and 50 character")
+    private String username;
+
+    @NotBlank(message="Email cannot be blank")
+    @Email(message = "Email should be valid")
+    @Size(max = 100, message = "Email must not exceed 100 characters")
+    private String email;
+
+    @NotBlank(message="Password cannot be blank")
+    @Size(min = 6, max = 100, message = "Password must be between 6 and 100 characters")
+    private String password;
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/dto/UserResponse.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/dto/UserResponse.java
@@ -1,0 +1,14 @@
+package com.syntexa.api.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponse{
+    private Long id;
+    private String username;
+    private String email;
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/model/User.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/model/User.java
@@ -1,0 +1,27 @@
+package com.syntexa.api.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "app_users")
+public class User{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable=false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String password;
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/repository/UserRepository.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package com.syntexa.api.repository;
+
+import com.syntexa.api.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long>{
+    
+    Optional<User> findByUsername(String username);
+    Optional<User>findByEmail(String email);
+
+    Boolean existsByUsername(String username); 
+    Boolean existsByEmail(String email);
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/service/UserService.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/service/UserService.java
@@ -1,0 +1,37 @@
+package com.syntexa.api.service;
+
+import com.syntexa.api.model.User;
+import com.syntexa.api.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class UserService{
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder){
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User registerUser(User userToRegister){
+        if (userRepository.existsByUsername(userToRegister.getUsername())){
+            throw new IllegalArgumentException("Error: Username is already taken!");
+        }
+
+        if(userRepository.existsByEmail(userToRegister.getEmail())){
+            throw new IllegalArgumentException("Error: Email is already in use!");
+        }
+
+        String hashedPassword = passwordEncoder.encode(userToRegister.getPassword());
+        userToRegister.setPassword(hashedPassword);
+
+        User savedUser = userRepository.save(userToRegister);
+    
+        return savedUser;
+    }
+}

--- a/syntexa-api/src/main/resources/application.properties
+++ b/syntexa-api/src/main/resources/application.properties
@@ -3,8 +3,9 @@ server.port=8080
 
 # PostgreSQL Database Configuration
 spring.datasource.url=jdbc:postgresql://localhost:5432/syntexa_db
-spring.datasource.username=your_db_user    
-spring.datasource.password=your_db_password 
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/syntexa-api/src/test/java/com/syntexa/api/SyntexaApplicationTests.java
+++ b/syntexa-api/src/test/java/com/syntexa/api/SyntexaApplicationTests.java
@@ -6,8 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class SyntexaApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+    }
 }

--- a/syntexa-api/src/test/resources/application.properties
+++ b/syntexa-api/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
### **Description**
This pull request introduces the core user registration functionality for the Syntexa application. It establishes the foundational layers for user management, including the data model, repository, service, and a public-facing API endpoint for signing up.

This feature allows new users to create an account securely, with server-side validation and password hashing in place.

### **Changes Implemented**

- User Entity & DTOs:

1. Created User.java as a JPA entity mapped to the app_users table.
2. Created SignUpRequest.java DTO with validation annotations (@NotBlank, @Email, @Size) to handle and validate incoming registration data.
3. Created UserResponse.java DTO to safely return user data from the API, excluding sensitive information like the password hash.

- Repository & Service Layer:

1. Created UserRepository interface extending JpaRepository to provide standard CRUD operations and custom query methods (findByUsername, existsByEmail, etc.).
2. Implemented UserService containing the core business logic for user registration.
3. The service validates that the username and email are unique before creating a new user.
4. Passwords are securely hashed using BCryptPasswordEncoder before being persisted to the database.

- Controller Layer:

1. Created AuthController to handle authentication-related endpoints.
2. Added a public POST /api/v1/auth/signup endpoint to accept new user registrations.
3. The endpoint handles successful registration by returning a 201 Created status and handles exceptions (like duplicate user) by returning a 400 Bad Request status with an error message.

- Security Configuration:

1. Updated SecurityConfig.java to:
2. Provide a globally available PasswordEncoder bean (using BCryptPasswordEncoder).
3. Permit all unauthenticated access to authentication endpoints under /api/v1/auth/**.
4. Disable CSRF for easier stateless API testing with tools like Postman.

### **Testing Done**

- The /api/v1/auth/signup endpoint was manually tested using Postman for the following scenarios:

1. Successful Registration: A new user was created with a valid request, returning a 201 Created status and a success message.
2. Duplicate Username: Attempting to register with an existing username correctly returned a 400 Bad Request status and an appropriate error message.
3. Duplicate Email: Attempting to register with an existing email correctly returned a 400 Bad Request status and an appropriate error message.
4. Invalid Input: Requests with blank fields, invalid email formats, and short passwords were correctly rejected by the DTO validation layer, resulting in a 400 Bad Request.