### PR TITLE
feat: Implement JWT filter and secure endpoints

### DIFF
--- a/syntexa-api/src/main/java/com/syntexa/api/controller/DemoController.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/controller/DemoController.java
@@ -1,0 +1,17 @@
+package com.syntexa.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/demo") 
+public class DemoController {
+
+    @GetMapping("/hello-secure")
+    public ResponseEntity<String> sayHelloSecure() {
+        
+        return ResponseEntity.ok("Hello from a SECURE endpoint! Aap authenticated hain!");
+    }
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/security/JwtAuthenticationFilter.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/security/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.syntexa.api.security;
+
+import com.syntexa.api.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserService userService;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserService userService) {
+        this.jwtService = jwtService;
+        this.userService = userService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String jwt = authHeader.substring(7);
+        final String username = jwtService.extractUsername(jwt);
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = this.userService.loadUserByUsername(username);
+
+            if (jwtService.isTokenValid(jwt, userDetails)) {
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+                authToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
### **Description**
This pull request completes the authentication system by implementing a stateless, token-based security model using JSON Web Tokens (JWT).

Following user login, the application now uses a JwtAuthenticationFilter to validate tokens on subsequent requests, securing application endpoints and ensuring that only authenticated users can access protected resources. This replaces the previous stateful form-login mechanism.

### **Changes Implemented**

- JwtAuthenticationFilter Created:

1. A new filter, JwtAuthenticationFilter, has been added. It extends OncePerRequestFilter.
2. This filter intercepts every incoming request to check for a JWT in the Authorization: Bearer header.
3. If a valid token is found, it validates the token, extracts the username, loads the user's details, and sets the Authentication object in Spring's SecurityContextHolder.

- SecurityConfig Updated:

1. The SecurityFilterChain has been significantly updated to integrate the new filter.
2. Session management is now set to STATELESS (SessionCreationPolicy.STATELESS) as we no longer rely on server-side sessions.
3. The JwtAuthenticationFilter is now added to the filter chain before the UsernamePasswordAuthenticationFilter.
4. The default .formLogin() has been removed.

- Protected DemoController Added:

1. A new DemoController with a protected endpoint (GET /api/v1/demo/hello-secure) was created to test the new token-based security.
2. Access to this endpoint requires a valid JWT, as per the anyRequest().authenticated() rule.

### **Testing Done**

- The complete authentication flow was manually tested using Postman:

1. Login: Successfully logged in via POST /api/v1/auth/login to obtain a JWT.
2. Authorized Access: Successfully accessed the protected GET /api/v1/demo/hello-secure endpoint by providing the JWT in the Authorization: Bearer <token> header, receiving a 200 OK status and the success message.
3. Unauthorized Access: Attempting to access the protected GET /api/v1/demo/hello-secure endpoint without a token correctly resulted in a 403 Forbidden error, confirming the endpoint is secure.