### PR TITLE
feat: Implement CRUD operations for Challenges

### DIFF
--- a/syntexa-api/src/main/java/com/syntexa/api/controller/ChallengeController.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/controller/ChallengeController.java
@@ -1,0 +1,60 @@
+package com.syntexa.api.controller;
+
+import com.syntexa.api.model.Challenge;
+import com.syntexa.api.service.ChallengeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/challenges") 
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    @Autowired
+    public ChallengeController(ChallengeService challengeService) {
+        this.challengeService = challengeService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Challenge> createChallenge(@RequestBody Challenge challenge) {
+        Challenge newChallenge = challengeService.createChallenge(challenge);
+        return new ResponseEntity<>(newChallenge, HttpStatus.CREATED); // Status 201 Created
+    }
+
+    @GetMapping
+    public List<Challenge> getAllChallenges() {
+        return challengeService.getAllChallenges();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Challenge> getChallengeById(@PathVariable Long id) {
+        return challengeService.getChallengeById(id)
+                .map(challenge -> ResponseEntity.ok(challenge)) 
+                .orElse(ResponseEntity.notFound().build()); 
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Challenge> updateChallenge(@PathVariable Long id, @RequestBody Challenge challengeDetails) {
+        try {
+            Challenge updatedChallenge = challengeService.updateChallenge(id, challengeDetails);
+            return ResponseEntity.ok(updatedChallenge);
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteChallenge(@PathVariable Long id) {
+        try {
+            challengeService.deleteChallenge(id);
+            return ResponseEntity.noContent().build(); // Status 204 No Content
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/model/Challenge.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/model/Challenge.java
@@ -1,0 +1,30 @@
+package com.syntexa.api.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "challenges")
+public class Challenge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String difficulty; 
+
+    @Column(columnDefinition = "TEXT")
+    private String solution; 
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/repository/ChallengeRepository.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/repository/ChallengeRepository.java
@@ -1,0 +1,10 @@
+package com.syntexa.api.repository;
+
+import com.syntexa.api.model.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+}

--- a/syntexa-api/src/main/java/com/syntexa/api/service/ChallengeService.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/service/ChallengeService.java
@@ -1,0 +1,62 @@
+package com.syntexa.api.service;
+
+import com.syntexa.api.model.Challenge;
+import com.syntexa.api.repository.ChallengeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+
+    @Autowired
+    public ChallengeService(ChallengeRepository challengeRepository) {
+        this.challengeRepository = challengeRepository;
+    }
+
+    
+    public Challenge createChallenge(Challenge challenge) {
+        
+        return challengeRepository.save(challenge);
+    }
+
+    
+    public List<Challenge> getAllChallenges() {
+        return challengeRepository.findAll();
+    }
+
+    
+    public Optional<Challenge> getChallengeById(Long id) {
+        return challengeRepository.findById(id);
+    }
+
+    
+    public Challenge updateChallenge(Long id, Challenge challengeDetails) {
+        
+        Challenge challenge = challengeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Challenge not found with id: " + id));
+
+        
+        challenge.setTitle(challengeDetails.getTitle());
+        challenge.setDescription(challengeDetails.getDescription());
+        challenge.setDifficulty(challengeDetails.getDifficulty());
+        challenge.setSolution(challengeDetails.getSolution());
+
+        
+        return challengeRepository.save(challenge);
+    }
+
+    
+    public void deleteChallenge(Long id) {
+        
+        Challenge challenge = challengeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Challenge not found with id: " + id));
+
+        
+        challengeRepository.delete(challenge);
+    }
+}


### PR DESCRIPTION
### **Description**
This pull request implements the full CRUD (Create, Read, Update, Delete) functionality for managing "Challenges" in the Syntexa application.

This feature introduces the Challenge entity and provides a complete set of secure REST API endpoints for administrators (in the future) or authenticated users to manage the coding challenges that form the core content of the platform.

### **Changes Implemented**

- Challenge Entity:

1. Created a new JPA entity, Challenge.java, with fields such as id, title, description, difficulty, and solution.
2. Utilized @Column(columnDefinition = "TEXT") for longer description and solution fields.

- ChallengeRepository:

1. Created ChallengeRepository.java extending JpaRepository to provide all standard database operations for the Challenge entity out-of-the-box.

- ChallengeService:

1. Implemented ChallengeService.java to contain the business logic for all CRUD operations:
2. createChallenge: Saves a new challenge.
3. getAllChallenges: Retrieves a list of all challenges.
4. getChallengeById: Finds a specific challenge by its ID.
5. updateChallenge: Updates the details of an existing challenge.
6. deleteChallenge: Deletes a challenge by its ID.
7. Includes RuntimeException handling for cases where a challenge to be updated or deleted is not found.

- ChallengeController:

1. Created ChallengeController.java to expose the CRUD operations via RESTful API endpoints under the base path /api/v1/challenges.
2. Implemented the following secure endpoints:
3. POST /: Creates a new challenge.
4. GET /: Retrieves all challenges.
5. GET /{id}: Retrieves a single challenge by its ID.
6. PUT /{id}: Updates a challenge.
7. DELETE /{id}: Deletes a challenge.
8. All endpoints are protected and require a valid JWT for access, as enforced by the existing JwtAuthenticationFilter and SecurityConfig.

### **Testing Done**

- All new endpoints were manually tested using Postman:

- Authentication: First, a JWT was obtained by logging in via the /api/v1/auth/login endpoint.
- Authorization: The JWT was included as a Bearer Token in the Authorization header for all requests to the /challenges endpoints.

**CRUD Operations:**
✅ Create: Successfully created a new challenge using the POST endpoint (received 201 Created).
✅ Read (All): Successfully retrieved the list of all challenges using the GET endpoint (received 200 OK).
✅ Read (One): Successfully retrieved a single challenge by its ID using the GET /{id} endpoint (received 200 OK).
✅ Update: Successfully updated an existing challenge using the PUT /{id} endpoint (received 200 OK).
✅ Delete: Successfully deleted a challenge using the DELETE /{id} endpoint (received 204 No Content).
✅ Unauthorized Access: Confirmed that accessing any of these endpoints without a valid JWT correctly results in a 403 Forbidden error.