### PR TITLE
feat: Add Dockerfile for deployment setup

### DIFF
--- a/syntexa-api/.dockerignore
+++ b/syntexa-api/.dockerignore
@@ -1,0 +1,3 @@
+target/
+.git/
+.vscode/

--- a/syntexa-api/Dockerfile
+++ b/syntexa-api/Dockerfile
@@ -1,0 +1,34 @@
+# --- Stage 1: Build the application with Maven ---
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the Maven wrapper and pom.xml to leverage Docker cache
+COPY ./.mvn/ ./.mvn
+COPY ./mvnw ./mvnw
+COPY ./pom.xml ./pom.xml
+
+# Download all dependencies
+RUN ./mvnw dependency:go-offline
+
+# Copy the project source code
+COPY ./src ./src
+
+# Package the application using Maven, skipping tests
+RUN ./mvnw package -DskipTests
+
+# --- Stage 2: Create the final, smaller image ---
+FROM openjdk:17-jdk-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy only the built JAR from the 'build' stage
+COPY --from=build /app/target/syntexa-api-0.0.1-SNAPSHOT.jar app.jar
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Command to run the application when the container starts
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
### **Description**
This pull request prepares the Syntexa API for deployment by introducing containerization via Docker.

A Dockerfile has been added to define a standardized, portable environment for the application. This ensures that the application runs consistently across different environments (local development, staging, production) and simplifies the deployment process on modern cloud platforms like Render.

### **Changes Implemented**

- Dockerfile Added:

1. A multi-stage Dockerfile has been created at the root of the syntexa-api module.
2. Stage 1 (Build): Uses a maven base image to build the project, compile the source code, and package the application into an executable .jar file. This stage leverages Docker's layer caching for dependencies to speed up subsequent builds.
3. Stage 2 (Runtime): Uses a slim openjdk:17-jdk-slim base image for a smaller and more secure final image. It copies only the .jar file from the build stage.
4. The application port (8080) is exposed, and an ENTRYPOINT is defined to run the application when the container starts.

- .dockerignore Added:

1. A .dockerignore file has been added to exclude unnecessary files and directories (like target/, .git/, .vscode/) from the Docker build context. This improves build times and keeps the resulting image clean.