### PR TITLE
feat: Implement CRUD for Problems and Notes

### DIFF
--- a/syntexa-api/src/main/java/com/syntexa/api/controller/ProblemController.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/controller/ProblemController.java
@@ -19,13 +19,11 @@ public class ProblemController {
         this.problemService = problemService;
     }
 
-    
     @GetMapping
     public List<Problem> getAllProblems() {
         return problemService.getAllProblems();
     }
 
-    
     @GetMapping("/{id}")
     public ResponseEntity<Problem> getProblemById(@PathVariable Long id) {
         return problemService.getProblemById(id)
@@ -33,7 +31,7 @@ public class ProblemController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    
+    // Endpoint to create a new problem
     @PostMapping
     public ResponseEntity<Problem> createProblem(@RequestBody Problem problem) {
         Problem createdProblem = problemService.createProblem(problem);

--- a/syntexa-api/src/main/java/com/syntexa/api/service/ProblemService.java
+++ b/syntexa-api/src/main/java/com/syntexa/api/service/ProblemService.java
@@ -24,7 +24,8 @@ public class ProblemService {
     public Optional<Problem> getProblemById(Long id) {
         return problemRepository.findById(id);
     }
-
+    
+    // This method allows creating a new problem
     public Problem createProblem(Problem problem) {
         return problemRepository.save(problem);
     }


### PR DESCRIPTION
### **Description**
This pull request implements the primary feature of the Syntexa application: the "Coding Notes Hub". This feature transforms the platform into a collaborative space where developers can create topics for coding problems and collectively contribute various notes, solutions, and approaches.

### **Backend Changes Implemented**

- Data Model:

1. A new Problem.java entity was created to represent a coding problem or topic.
2. A new Note.java entity was created to store individual notes or approaches.
3. Relationships:
4. A OneToMany relationship was established from Problem to Note (One problem can have many notes).
5. A ManyToOne relationship was established from Note to User to track the author of each note.
6. Added @JsonIgnoreProperties to entities to handle circular references during JSON serialization.

- API & Service Layers:

1. New repositories (ProblemRepository, NoteRepository) were created.
2. New services (ProblemService, NoteService) were implemented to handle the business logic for creating and retrieving problems and notes.
3. New controllers (ProblemController, NoteController) were created to expose the functionality via RESTful endpoints.

API Endpoints:

1. GET /api/v1/problems: Retrieves a list of all problems.
2. GET /api/v1/problems/{id}: Retrieves a single problem and its associated notes.
3. POST /api/v1/problems: A protected endpoint for authenticated users to create a new problem topic.
4. POST /api/v1/problems/{problemId}/notes: A protected endpoint for authenticated users to add a new note to a specific problem.

- Security Configuration:

1. SecurityConfig.java was updated to allow public GET access to the /api/v1/problems/** endpoints.
2. All POST requests to create problems or notes remain protected, requiring a valid JWT.